### PR TITLE
CB using Surprise Points

### DIFF
--- a/SurpriseIndex.Rmd
+++ b/SurpriseIndex.Rmd
@@ -63,6 +63,8 @@ data <- data %>%
 
 data <- data %>% mutate(Surprise_Points = ifelse((FTR == 'A' & HTP < ATP) | (FTR == 'H' & HTP > ATP), 2,
                                          ifelse(FTR == 'D' , 1, 0)))
+
+data <- data %>% mutate(Surprise_Points = Surprise_Points*abs(HTP-ATP))
 ```
 
 ```{r}
@@ -78,13 +80,13 @@ sp <- sp %>% mutate(S = Surprise_Points/M)
 ```
 
 ```{r}
-HHI <- f %>% group_by(SEASON, COUNTRY) %>%
-  mutate(Perc = Total_Points / sum(Total_Points)) %>%
-  summarise(HHI = sum(Perc^2))
+CB <- f %>% group_by(SEASON, COUNTRY) %>%
+  mutate(Perc = Total_Points / sum(Total_Points) ) %>%
+  summarise(N = n(), id_s = 0.5/sqrt(N),  HHI = sum(Perc^2) - 1/N, NS = sd(Perc)/id_s)
 
 
-HHI <- HHI %>% 
-  left_join(select(sp, SEASON, COUNTRY, S, N), by = c("SEASON" = "SEASON", "COUNTRY" = "COUNTRY"))
+CB <- CB %>% 
+  left_join(select(sp, SEASON, COUNTRY, S), by = c("SEASON" = "SEASON", "COUNTRY" = "COUNTRY"))
 
 ```
 
@@ -92,18 +94,18 @@ HHI <- HHI %>%
 
 country <- "England"
 
-ggplot(HHI %>% filter(COUNTRY == country), aes(SEASON, 1-HHI)) + geom_point() + geom_line()
+ggplot(CB %>% filter(COUNTRY == country), aes(SEASON, 1-HHI)) + geom_point() + geom_line()
 ```
 
 ```{r}
 
-ggplot(HHI %>% filter(COUNTRY == country), aes(SEASON, S)) + geom_point() + geom_line()
+ggplot(CB %>% filter(COUNTRY == country), aes(SEASON, S)) + geom_point() + geom_line()
 
 ```
 
 
 ```{r}
-  ggplot(HHI %>% filter(COUNTRY != "Scotland"), aes(HHI, S)) + geom_point() + geom_smooth(method = lm) + facet_wrap(~COUNTRY)
+ggplot(CB , aes(HHI, S)) + geom_point()  + facet_wrap(~COUNTRY)
 ```
 
 

--- a/SurpriseIndex.Rmd
+++ b/SurpriseIndex.Rmd
@@ -1,0 +1,114 @@
+---
+title: "Surprise Index"
+author: "Barsegh Atanyan"
+date: "11/29/2020"
+output: pdf_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(SportsAnalytics270)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+library(reshape2)
+
+```
+
+```{r}
+data("f_data_sm")
+data <- f_data_sm %>%
+  select(-c("H","D", "A"))
+
+data <- data %>% drop_na()
+
+f_long <- data %>%
+  select(SEASON, COUNTRY, DATE,HOMETEAM,AWAYTEAM,FTSC) %>%
+  gather(key='flag', value = 'Team',-c(SEASON, COUNTRY, FTSC,DATE)) %>%
+  separate(FTSC, into = c('g1','g2'),sep = '-') %>%
+  mutate(scored=ifelse(flag=='HOMETEAM',as.numeric(g1),as.numeric(g2)),
+         conceded=ifelse(flag=='HOMETEAM',as.numeric(g2),as.numeric(g1)),
+        WL=ifelse(scored>conceded,'W',ifelse(scored<conceded,"L",'D')),
+        Points=ifelse(scored>conceded,3,ifelse(scored<conceded,0,1))) %>%
+    select(-c(g1,g2))
+
+
+f <- f_long %>%
+  group_by(SEASON, COUNTRY, Team, WL) %>%
+  summarise(Total_Points = sum(Points), Matches = n(), scored = sum(scored), 
+            conceded = sum(conceded)) %>%
+  group_by(SEASON, COUNTRY) %>%
+  spread(WL,Matches) %>%
+  group_by(SEASON, COUNTRY, Team) %>%
+  summarise(Scored=sum(scored), Conceded=sum(conceded),W=sum(W,na.rm = TRUE), 
+            D=sum(D,na.rm = TRUE),L=sum(L,na.rm = TRUE),Total_Points=sum(Total_Points)) %>%
+  mutate(Position = dense_rank(desc(rank(Total_Points,ties.method = "first"))),
+         Matches=D+L+W)%>%
+  arrange(Position)
+
+```
+
+
+```{r}
+
+
+data <- data %>% 
+  left_join(select(f, SEASON, COUNTRY, Team, Position), by = c("SEASON" = "SEASON", "COUNTRY" = "COUNTRY", "HOMETEAM" = "Team")) %>%
+  rename(HTP = Position)
+
+data <- data %>% 
+  left_join(select(f, SEASON, COUNTRY, Team, Position), by = c("SEASON" = "SEASON", "COUNTRY" = "COUNTRY", "AWAYTEAM" = "Team")) %>%
+  rename(ATP = Position)
+
+
+data <- data %>% mutate(Surprise_Points = ifelse((FTR == 'A' & HTP < ATP) | (FTR == 'H' & HTP > ATP), 2,
+                                         ifelse(FTR == 'D' , 1, 0)))
+```
+
+```{r}
+
+sp <- data %>% group_by(SEASON, COUNTRY) %>% summarize(Surprise_Points = sum(Surprise_Points))
+
+
+sp <- sp %>% left_join(f %>% group_by(SEASON, COUNTRY) %>% summarise(N = n()))
+sp <- sp %>% mutate(M = (N - 1) * N * (N + 1) / 3)
+
+sp <- sp %>% mutate(S = Surprise_Points/M)
+
+```
+
+```{r}
+HHI <- f %>% group_by(SEASON, COUNTRY) %>%
+  mutate(Perc = Total_Points / sum(Total_Points)) %>%
+  summarise(HHI = sum(Perc^2))
+
+
+HHI <- HHI %>% 
+  left_join(select(sp, SEASON, COUNTRY, S, N), by = c("SEASON" = "SEASON", "COUNTRY" = "COUNTRY"))
+
+```
+
+```{r}
+
+country <- "England"
+
+ggplot(HHI %>% filter(COUNTRY == country), aes(SEASON, 1-HHI)) + geom_point() + geom_line()
+```
+
+```{r}
+
+ggplot(HHI %>% filter(COUNTRY == country), aes(SEASON, S)) + geom_point() + geom_line()
+
+```
+
+
+```{r}
+  ggplot(HHI %>% filter(COUNTRY != "Scotland"), aes(HHI, S)) + geom_point() + geom_smooth(method = lm) + facet_wrap(~COUNTRY)
+```
+
+
+
+
+
+
+


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2020-11-30 at 00 34 23" src="https://user-images.githubusercontent.com/33234429/100552916-ccaed500-32a3-11eb-8ff7-507b25510a16.png">

We can see strong linear correlation between the competitive balance obtained in two ways - HHI and Surprise Points.
Though, as number of teams in a single season may change, we get kind of two lines. This number of teams should be taken into consideration somehow to normalize the numbers.

<img width="1792" alt="Screen Shot 2020-11-30 at 00 39 31" src="https://user-images.githubusercontent.com/33234429/100553014-84dc7d80-32a4-11eb-8df2-a0af66bfaae5.png">
